### PR TITLE
NumberFormat - Fix NavigationLink crash

### DIFF
--- a/NumberSample/NumberSample/CurrencyUITextField.swift
+++ b/NumberSample/NumberSample/CurrencyUITextField.swift
@@ -25,11 +25,16 @@ class CurrencyUITextField: UITextField {
     }
 
     override func willMove(toSuperview newSuperview: UIView?) {
+        super.willMove(toSuperview: superview)
         addTarget(self, action: #selector(editingChanged), for: .editingChanged)
         addTarget(self, action: #selector(resetSelection), for: .allTouchEvents)
         keyboardType = .numberPad
         textAlignment = .right
         sendActions(for: .editingChanged)
+    }
+
+    override func removeFromSuperview() {
+        print(#function)
     }
 
     override func deleteBackward() {
@@ -53,8 +58,8 @@ class CurrencyUITextField: UITextField {
     }
 
     private func updateValue() {
-        DispatchQueue.main.async {
-            self.value = self.intValue
+        DispatchQueue.main.async { [weak self] in
+            self?.value = self?.intValue ?? 0
         }
     }
 


### PR DESCRIPTION
## Issue https://github.com/popei69/samples/issues/7

Without real hint why but debugging through memory, it seems if the UI view calls `removeFromSuperview` it doesn't actually deinit the view and eventually crash.

Overriding it to not do that allows to deinit. I don't really see the link but found similar deinit issues around SwiftUI like [here](https://developer.apple.com/forums/thread/118582)

Also cleaned few other things.