### PR TITLE
Currency Field Initial Value Update

### DIFF
--- a/NumberSample/NumberSample/CurrencyUITextField.swift
+++ b/NumberSample/NumberSample/CurrencyUITextField.swift
@@ -45,6 +45,15 @@ class CurrencyUITextField: UITextField {
     private func setupViews() {
         tintColor = .clear
         font = .systemFont(ofSize: 40, weight: .regular)
+        setInitialValue()
+    }
+    
+    private func setInitialValue() {
+        if value > 0 {
+            let val = Double(value)
+            let decimalValue = Decimal(val / 100.0)
+            text = currency(from: decimalValue)
+        }
     }
 
     @objc private func editingChanged() {


### PR DESCRIPTION
**Changed:**

If you want an initial value set in the text field (for example, you are editing a post sale price) the field would show the text as $0.00.

This change allows you to set an initial value for the text field.
