### PR TITLE
Fix iOS17+ crash

### DIFF
--- a/NumberSample/NumberSample/CurrencyUITextField.swift
+++ b/NumberSample/NumberSample/CurrencyUITextField.swift
@@ -33,10 +33,6 @@ class CurrencyUITextField: UITextField {
         sendActions(for: .editingChanged)
     }
 
-    override func removeFromSuperview() {
-        print(#function)
-    }
-
     override func deleteBackward() {
         text = textValue.digits.dropLast().string
         sendActions(for: .editingChanged)


### PR DESCRIPTION
@popei69 
Believe it or not but the previous fix started crashing on iOS17+. I was hunting this bags for weeks. Basically if you open a type a number in CurrencyUITextField and then dismiss the view, the app crashes (`libobjc.A.dylib | objc_msgSend + 32`). 
I think iOS17 support is more valuable... 
Not sure if `#if available(iOS 17, *) { } #else { }` is needed...